### PR TITLE
双拼声母韵母匹配失效问题，Keyboard切分函数的问题

### DIFF
--- a/src/main/java/me/towdium/pinin/Keyboard.java
+++ b/src/main/java/me/towdium/pinin/Keyboard.java
@@ -119,11 +119,11 @@ public class Keyboard {
     public static Keyboard DAQIAN = new Keyboard(PHONETIC_LOCAL, DAQIAN_KEYS, Keyboard::standard, false, false);
     public static Keyboard XIAOHE = new Keyboard(null, XIAOHE_KEYS, Keyboard::zero, true, false);
     public static Keyboard ZIRANMA = new Keyboard(null, ZIRANMA_KEYS, Keyboard::zero, true, false);
-    public static Keyboard SOUGOU = new Keyboard(null, SOUGOU_KEYS, Keyboard::zero, true, false);
-    public static Keyboard GUOBIAO = new Keyboard(null, GUOBIAO_KEYS, Keyboard::zero, true, false);
-    public static Keyboard MICROSOFT = new Keyboard(null, MICROSOFT_KEYS, Keyboard::zero, true, false);
-    public static Keyboard PINYINPP = new Keyboard(null, PINYINPP_KEYS, Keyboard::zero, true, false);
-    public static Keyboard ZIGUANG = new Keyboard(null, ZIGUANG_KEYS, Keyboard::zero, true, false);
+    public static Keyboard SOUGOU = new Keyboard(null, SOUGOU_KEYS, Keyboard::zeroOInitial, true, false);
+    public static Keyboard GUOBIAO = new Keyboard(null, GUOBIAO_KEYS, Keyboard::zeroAInitial, true, false);
+    public static Keyboard MICROSOFT = new Keyboard(null, MICROSOFT_KEYS, Keyboard::zeroOInitial, true, false);
+    public static Keyboard PINYINPP = new Keyboard(null, PINYINPP_KEYS, Keyboard::zeroFirstInitial, true, false);
+    public static Keyboard ZIGUANG = new Keyboard(null, ZIGUANG_KEYS, Keyboard::zeroOInitial, true, false);
 
     final Map<String, String> local;
     final Map<String, String> keys;
@@ -171,6 +171,32 @@ public class Keyboard {
             String finale = ss.get(0);
             ss.set(0, Character.toString(finale.charAt(0)));
             ss.add(1, finale.length() == 2 ? Character.toString(finale.charAt(1)) : finale);
+        }
+        return ss;
+    }
+
+    public static List<String> zeroOInitial(String s) {
+        List<String> ss = standard(s);
+        if (ss.size() == 2) {
+            ss.add(0,"o");
+        }
+        return ss;
+    }
+
+    public static List<String> zeroAInitial(String s) {
+        List<String> ss = standard(s);
+        if (ss.size() == 2) {
+            ss.add(0,"a");
+        }
+        return ss;
+    }
+
+    public static List<String> zeroFirstInitial(String s) {
+        List<String> ss = standard(s);
+        if (ss.size() == 2) {
+            String finale = ss.get(0);
+            ss.set(0, Character.toString(finale.charAt(0)));
+            ss.add(1,finale);
         }
         return ss;
     }

--- a/src/main/java/me/towdium/pinin/Keyboard.java
+++ b/src/main/java/me/towdium/pinin/Keyboard.java
@@ -120,6 +120,7 @@ public class Keyboard {
     public static Keyboard XIAOHE = new Keyboard(null, XIAOHE_KEYS, Keyboard::zero, true, false);
     public static Keyboard ZIRANMA = new Keyboard(null, ZIRANMA_KEYS, Keyboard::zero, true, false);
     public static Keyboard SOUGOU = new Keyboard(null, SOUGOU_KEYS, Keyboard::zeroOInitial, true, false);
+    public static Keyboard ZHINENG_ABC = new Keyboard(null, ZHINENG_ABC_KEYS, Keyboard::zeroOInitial, true, false);
     public static Keyboard GUOBIAO = new Keyboard(null, GUOBIAO_KEYS, Keyboard::zeroAInitial, true, false);
     public static Keyboard MICROSOFT = new Keyboard(null, MICROSOFT_KEYS, Keyboard::zeroOInitial, true, false);
     public static Keyboard PINYINPP = new Keyboard(null, PINYINPP_KEYS, Keyboard::zeroFirstInitial, true, false);

--- a/src/main/java/me/towdium/pinin/elements/Phoneme.java
+++ b/src/main/java/me/towdium/pinin/elements/Phoneme.java
@@ -56,7 +56,7 @@ public class Phoneme implements Element {
         if (strs.length == 1 && strs[0].isEmpty()) return ret;
         for (String str : strs) {
             int size = strCmp(source, str, start);
-            if (partial && start + size == source.length()) ret.set(size);  // ending match
+            if (partial && size != 0 && start + size == source.length()) ret.set(size);  // ending match
             else if (size == str.length()) ret.set(size); // full match
         }
         return ret;

--- a/src/main/java/me/towdium/pinin/utils/IndexSet.java
+++ b/src/main/java/me/towdium/pinin/utils/IndexSet.java
@@ -97,11 +97,8 @@ public class IndexSet {
     }
 
     static class Storage {
-        ThreadLocal<IndexSet> tmp;
+        IndexSet tmp = new Immutable();
         int[] data = new int[16];
-        Storage(){
-            tmp = ThreadLocal.withInitial(Immutable::new);
-        }
 
         public void set(IndexSet is, int index) {
             if (index >= data.length) {
@@ -123,10 +120,8 @@ public class IndexSet {
             if (index >= data.length) return null;
             int ret = data[index];
             if (ret == 0) return null;
-            
-            IndexSet resultTmp = tmp.get();
-            resultTmp.value = ret - 1;
-            return resultTmp;
+            tmp.value = ret - 1;
+            return tmp;
         }
     }
 }

--- a/src/main/java/me/towdium/pinin/utils/IndexSet.java
+++ b/src/main/java/me/towdium/pinin/utils/IndexSet.java
@@ -97,8 +97,11 @@ public class IndexSet {
     }
 
     static class Storage {
-        IndexSet tmp = new Immutable();
+        ThreadLocal<IndexSet> tmp;
         int[] data = new int[16];
+        Storage(){
+            tmp = ThreadLocal.withInitial(Immutable::new);
+        }
 
         public void set(IndexSet is, int index) {
             if (index >= data.length) {
@@ -120,8 +123,10 @@ public class IndexSet {
             if (index >= data.length) return null;
             int ret = data[index];
             if (ret == 0) return null;
-            tmp.value = ret - 1;
-            return tmp;
+            
+            IndexSet resultTmp = tmp.get();
+            resultTmp.value = ret - 1;
+            return resultTmp;
         }
     }
 }

--- a/src/test/java/me/towdium/pinin/PinInTest.java
+++ b/src/test/java/me/towdium/pinin/PinInTest.java
@@ -181,7 +181,7 @@ public class PinInTest {
         assert p.contains("测试文本", "ceuiwfbf");
         assert p.contains("测试文本", "ceuiwf2");
         assert !p.contains("测试文本", "ceuiw2");
-        assert p.contains("合金炉", "hej");
+        assert !p.contains("合金炉", "hej");
         assert p.contains("洗矿场", "xikl4");
         assert p.contains("月球", "ytqq");
     }
@@ -192,7 +192,7 @@ public class PinInTest {
         assert p.contains("测试文本", "ceuiwfbf");
         assert p.contains("测试文本", "ceuiwf2");
         assert !p.contains("测试文本", "ceuiw2");
-        assert p.contains("合金炉", "hej");
+        assert !p.contains("合金炉", "hej");
         assert p.contains("洗矿场", "xikd4");
         assert p.contains("月球", "ytqq");
         assert p.contains("安全", "anqr");


### PR DESCRIPTION
如标题所述

1.双拼声母韵母匹配失效问题
双拼匹配要求声母韵母同时存在，但是存在失效问题
双拼声母韵母匹配失效问题来源于没有检查strCmp返回的是否为0
有时候start如果等于了source.length()就会导致双拼要求的声母韵母同时存在的规则失效
要检查strCmp返回的是否为0，如果为0，那么代表没有匹配成功的字符串

2.Keyboard切分函数的问题
之前添加的Keyboard的一些新键位设计，没有去考虑到其对应的零声母规则，我已经实现了他们对应的零声母规则：
zeroOInitial: 如果没有声母，则用o作为声母 (搜狗，微软，紫光)
zeroAInitial: 如果没有声母，则用a作为声母 (国标)

3.新增搜狗。智能ABC，国标，微软，拼音加加，紫光双拼方案的测试样例
修正国标方案中缺失的ue->x的映射
新增关于自然码等零声母方案中的特例的测试样例，即当字零声母，韵母为3字母韵母时，应当为韵母第一个字符+韵母键位（昂撒人）

额外：原本智能ABC双拼打了表但是忘记填写字段了，现在加上了